### PR TITLE
Implement Reset Event workflow with Flutter-side command deletion

### DIFF
--- a/RESET_EVENT_IMPLEMENTATION.md
+++ b/RESET_EVENT_IMPLEMENTATION.md
@@ -1,0 +1,145 @@
+# Reset Event Implementation
+
+## Overview
+Implemented a complete "Reset Event" workflow that clears all data and returns the ESP32 to rainbow mode using Flutter-side command deletion.
+
+## Changes Made
+
+### 1. Flutter Side (`firestore_service.dart`)
+
+#### Added New Methods:
+- **`sendResetCommand()`** - Sends `run_reset` command to ESP32 via Realtime Database
+- **`deleteAllRealtimeCommands()`** - Deletes ALL commands from Realtime Database using REST API
+
+#### Updated Methods:
+- **`resetGenderRevealEvent()`** - Now performs complete reset workflow:
+  1. Clears all boy votes from Firestore
+  2. Clears all girl votes from Firestore
+  3. Clears all user latest votes from Firestore
+  4. Resets reveal status to false
+  5. **Deletes all pending commands from Realtime Database** 🆕
+  6. **Sends `run_reset` command to ESP32** 🆕
+
+### 2. ESP32 Side (`main.cpp`)
+
+#### Added New Command Handler:
+- **`run_reset`** command - Stops all effects and returns to rainbow mode
+  - Stops rainbow effect
+  - Stops running effect
+  - Stops theme animation
+  - Stops fast blink
+  - Resets theme timer
+  - Starts fresh rainbow effect at full brightness
+
+## Reset Workflow
+
+```
+User presses "Reset Event" button
+         ↓
+Flutter: Delete all votes from Firestore
+         ↓
+Flutter: Reset reveal status to false
+         ↓
+Flutter: DELETE entire esp32_commands node from Realtime Database
+         ↓
+Flutter: Send new "run_reset" command to Realtime Database
+         ↓
+ESP32: Receives run_reset command
+         ↓
+ESP32: Stops all active effects
+         ↓
+ESP32: Starts rainbow effect (default mode)
+         ↓
+✅ System fully reset!
+```
+
+## Key Features
+
+### Flutter-Side Command Deletion
+- **Why?** Simpler and more reliable than ESP32-side deletion
+- **How?** Uses Firebase REST API to delete entire `esp32_commands` node
+- **When?** Before sending the reset command, ensuring clean slate
+- **Web-compatible:** Works on all platforms (web, mobile, desktop)
+
+### Clean Database State
+- Old commands are completely removed before reset
+- No leftover reveal animations or theme commands
+- Fresh start with only the reset command
+
+### Robust Error Handling
+- Command deletion errors don't block the reset process
+- Reset continues even if Realtime Database cleanup fails
+- Logs all operations for debugging
+
+## Testing Checklist
+
+- [ ] Press "Reset Event" button on web app
+- [ ] Verify all votes are cleared from Firestore
+- [ ] Check Realtime Database - all old commands should be deleted
+- [ ] Verify ESP32 returns to rainbow mode
+- [ ] Confirm new voting works after reset
+- [ ] Test reveal animation works after reset
+
+## Firebase Realtime Database Structure
+
+### Before Reset:
+```json
+{
+  "esp32_commands": {
+    "-Web1234567890": {
+      "command": "set_blinking",
+      "parameters": {...},
+      "timestamp": 1234567890
+    },
+    "-Web9876543210": {
+      "command": "set_theme",
+      "parameters": {...},
+      "timestamp": 9876543210
+    }
+  }
+}
+```
+
+### After Delete (Temporary):
+```json
+{
+  "esp32_commands": null
+}
+```
+
+### After Reset Command:
+```json
+{
+  "esp32_commands": {
+    "-Web1733677200": {
+      "command": "run_reset",
+      "parameters": {},
+      "timestamp": 1733677200,
+      "createdBy": "user-uid"
+    }
+  }
+}
+```
+
+## Notes
+
+- ESP32 does NOT delete commands automatically (by design, for LED animation smoothness)
+- Flutter handles all command lifecycle management
+- Reset command is the ONLY command in database after reset
+- ESP32 simply executes whatever commands exist in the database
+
+## Next Steps
+
+1. **Upload ESP32 firmware** with new `run_reset` handler
+2. **Deploy Flutter web app** with updated reset logic
+3. **Test complete workflow** on deployed site
+4. **Monitor Realtime Database** to confirm clean deletion
+
+## Benefits
+
+✅ Clean database after reset  
+✅ No command accumulation  
+✅ Reliable ESP32 reset to rainbow  
+✅ Web-compatible (REST API)  
+✅ Simple to debug and maintain  
+✅ No ESP32 code changes needed for command deletion  


### PR DESCRIPTION
- Add run_reset command handler to ESP32 firmware
- Add sendResetCommand() method to send reset command via Realtime Database
- Add deleteAllRealtimeCommands() method to clear all pending commands
- Update resetGenderRevealEvent() to delete commands before sending reset
- ESP32 now stops all effects and returns to rainbow on reset command
- Flutter handles all command lifecycle management via REST API
- Create RESET_EVENT_IMPLEMENTATION.md documentation